### PR TITLE
Add original form id and random form id to gform_multiple_instances_strings filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ Additionally, the plugin offers the following actions & filters:
 ##### gform\_multiple\_instances\_strings
 
 **$strings**   *(array)*. An array of find => replace pairs. Occurences of "key" will be replaced with the corresponding "value".
+
 **$form_id**   *(int)*.   The original form id.
+
 **$random_id** *(int)*.   The new, randomly generated form id.
 
 This filter allows you to modify the default strings that will be replaced. The keys are the original strings, and the corresponding values are the strings that keys will be replaced with.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Additionally, the plugin offers the following actions & filters:
 
 ##### gform\_multiple\_instances\_strings
 
-**$strings** *(array)*. An array of find => replace pairs. Occurences of "key" will be replaced with the corresponding "value".
+**$strings**   *(array)*. An array of find => replace pairs. Occurences of "key" will be replaced with the corresponding "value".
+**$form_id**   *(int)*.   The original form id.
+**$random_id** *(int)*.   The new, randomly generated form id.
 
 This filter allows you to modify the default strings that will be replaced. The keys are the original strings, and the corresponding values are the strings that keys will be replaced with.

--- a/gravityforms-multiple-form-instances.php
+++ b/gravityforms-multiple-form-instances.php
@@ -99,7 +99,7 @@ class Gravity_Forms_Multiple_Form_Instances {
 		);
 
 		// allow addons & plugins to add additional find & replace strings
-		$strings = apply_filters( 'gform_multiple_instances_strings', $strings );
+		$strings = apply_filters( 'gform_multiple_instances_strings', $strings, $form['id'], $random_id );
 
 		// replace all occurences with the new unique ID
 		foreach ( $strings as $find => $replace ) {

--- a/tests/unit-tests/GFMFI_GformGetFormFilterTest.php
+++ b/tests/unit-tests/GFMFI_GformGetFormFilterTest.php
@@ -509,7 +509,7 @@ class GFMFI_GformGetFormFilterTest extends WP_UnitTestCase {
 	 * @covers Gravity_Forms_Multiple_Form_Instances::gform_get_form_filter
 	 */
 	public function testGformMultipleInstancesStringsFilter() {
-		add_filter( 'gform_multiple_instances_strings', array($this, 'gform_multiple_instances_strings') );
+		add_filter( 'gform_multiple_instances_strings', array($this, 'gform_multiple_instances_strings'), 10, 3 );
 
 		$input = 'foo_' . $this->form['id'] . '_';
 		$expected = 'foo_' . $this->randomId . '_';
@@ -517,7 +517,7 @@ class GFMFI_GformGetFormFilterTest extends WP_UnitTestCase {
 
 		$this->assertSame( $expected, $actual );
 
-		remove_filter( 'gform_multiple_instances_strings', array($this, 'gform_multiple_instances_strings') );
+		remove_filter( 'gform_multiple_instances_strings', array($this, 'gform_multiple_instances_strings'), 10 );
 	}
 
 }

--- a/tests/unit-tests/GFMFI_GformGetFormFilterTest.php
+++ b/tests/unit-tests/GFMFI_GformGetFormFilterTest.php
@@ -2,8 +2,8 @@
 
 class GFMFI_GformGetFormFilterTest extends WP_UnitTestCase {
 
-	public function gform_multiple_instances_strings( $strings ) {
-		$strings['fooBar'] = 'barFoo';
+	public function gform_multiple_instances_strings( $strings, $form_id, $random_id ) {
+		$strings['foo_' . $form_id . '_'] = 'foo_' . $random_id . '_';
 		return $strings;
 	}
 
@@ -511,8 +511,8 @@ class GFMFI_GformGetFormFilterTest extends WP_UnitTestCase {
 	public function testGformMultipleInstancesStringsFilter() {
 		add_filter( 'gform_multiple_instances_strings', array($this, 'gform_multiple_instances_strings') );
 
-		$input = "fooBar";
-		$expected = "barFoo";
+		$input = 'foo_' . $this->form['id'] . '_';
+		$expected = 'foo_' . $this->randomId . '_';
 		$actual = $this->gfmfi->gform_get_form_filter( $input, $this->form );
 
 		$this->assertSame( $expected, $actual );


### PR DESCRIPTION
to allow clearer and less error prone code in hooked functions, by avoiding string replacements to determine the ids.