### PR TITLE
Fix confirmation message

### DIFF
--- a/gravityforms-multiple-form-instances.php
+++ b/gravityforms-multiple-form-instances.php
@@ -26,6 +26,7 @@ class Gravity_Forms_Multiple_Form_Instances {
 	public function __construct() {
 		// hook the HTML ID string find & replace functionality
 		add_filter( 'gform_get_form_filter', array( $this, 'gform_get_form_filter' ), 10, 2 );
+		add_filter( 'gform_confirmation', array( $this, 'gform_get_form_filter' ), 10, 2 );
 	}
 
 	/**

--- a/tests/unit-tests/GFMFI_ConstructTest.php
+++ b/tests/unit-tests/GFMFI_ConstructTest.php
@@ -19,4 +19,13 @@ class GFMFI_ConstructTest extends WP_UnitTestCase {
 		$this->assertSame( 10, has_filter( 'gform_get_form_filter', array( $this->gfmfi, 'gform_get_form_filter' ) ) );
 	}
 
+	/**
+	 * @covers Gravity_Forms_Multiple_Form_Instances::__construct
+	 */
+	public function testHookGformConfirmationRegistered() {
+		$this->gfmfi->__construct();
+
+		$this->assertSame( 10, has_filter( 'gform_confirmation', array( $this->gfmfi, 'gform_get_form_filter' ) ) );
+	}
+
 }


### PR DESCRIPTION
Hi,

This PR replaces the form id in the confirmation message.

Before : 
![dom](https://user-images.githubusercontent.com/10757301/36314967-c362f0b0-1336-11e8-91e2-4f235739ec44.png)

After : 
![dom-after](https://user-images.githubusercontent.com/10757301/36315217-65b8225e-1337-11e8-83c8-cb288e92afba.png)

If the ID is not replaced, the browser doesn't scroll to form anchor after confirmation and a javascript error appears in the console.

I think, it is the problem mentioned in this review : https://wordpress.org/support/topic/plugin-broken-cannot-read-top-of-undefined/

