### PR TITLE
Fix bug where multiple non-ajax forms, with validation errors, breaks conditional logic.

### DIFF
--- a/gravityforms-multiple-form-instances.php
+++ b/gravityforms-multiple-form-instances.php
@@ -137,7 +137,7 @@ class Gravity_Forms_Multiple_Form_Instances {
 			'GFCalc(' . $form['id'] . ','                                       => 'GFCalc(' . $random_id . ',',
 			'gf_global["number_formats"][' . $form['id'] . ']'                  => 'gf_global["number_formats"][' . $random_id . ']',
 			'gform_next_button_' . $form['id'] . '_'                            => 'gform_next_button_' . $random_id . '_',
-			$hidden_field                                                       => "<input type='hidden' name='gform_instance_count' value='" . $this->instance_counts[ $form['id'] ] . "' /><input type='hidden' name='gform_original_id' value='" . $form['id'] . "' /><input type='hidden' name='gform_random_id' value='" . $random_id . "' />" . $hidden_field,
+			$hidden_field                                                       => "<input type='hidden' name='gform_instance_count' value='" . $instance_number . "' /><input type='hidden' name='gform_original_id' value='" . $form['id'] . "' /><input type='hidden' name='gform_random_id' value='" . $random_id . "' />" . $hidden_field,
 		);
 
 		// allow addons & plugins to add additional find & replace strings

--- a/gravityforms-multiple-form-instances.php
+++ b/gravityforms-multiple-form-instances.php
@@ -16,6 +16,8 @@
  */
 class Gravity_Forms_Multiple_Form_Instances {
 
+	private $instance_count = Array();
+
 	/**
 	 * Constructor.
 	 *
@@ -41,10 +43,49 @@ class Gravity_Forms_Multiple_Form_Instances {
 	 * @return string $form_string The modified form HTML string.
 	 */
 	public function gform_get_form_filter( $form_string, $form ) {
-		// if form has been submitted, use the submitted ID, otherwise generate a new unique ID
-		if ( isset( $_POST['gform_random_id'] ) ) {
-			$random_id = absint( $_POST['gform_random_id'] ); // Input var okay.
+		
+		global $_POST;
+
+		$random_id = null;
+
+		//	Keep track of the instance number for each form type 
+		if (!array_key_exists($form['id'], $this->instance_count)) {
+			$this->instance_count[ $form['id'] ] = 1;
 		} else {
+			$this->instance_count[ $form['id'] ] = $this->instance_count[ $form['id'] ] + 1;
+		}
+
+		//	Get the instance number for this particular form 
+		$instance_number = $this->instance_count[ $form['id'] ];
+
+		//	Are we processing after a form has just been submitted?
+		if ( isset( $_POST['gform_random_id'] )) {
+
+			//	Is it of the same type as the form we're currently modifying? 
+			if ((isset( $_POST['gform_original_id'] ) && $_POST['gform_original_id'] == $form['id'] )) {
+
+				//	Is it an ajax submission? 
+				if (array_key_exists('gform_ajax', $_POST)) {
+
+					//	Yes, use the previous random ID
+					$random_id = absint( $_POST['gform_random_id'] );
+
+					//	Also use the previous instance ID
+					$instance_number = absint( $_POST['gform_instance_number'] );
+				}
+				
+				//	Is it the same instance of the form?
+				else if (isset( $_POST['gform_instance_number'] ) && $_POST['gform_instance_number'] == $instance_number ) {
+
+					//	Yes, use the previous random ID
+					$random_id = absint( $_POST['gform_random_id'] );
+				
+				}
+			}
+		}
+
+		//	Otherwise generate a new unique ID
+		if (!$random_id) {
 			$random_id = mt_rand();
 		}
 

--- a/gravityforms-multiple-form-instances.php
+++ b/gravityforms-multiple-form-instances.php
@@ -96,7 +96,7 @@ class Gravity_Forms_Multiple_Form_Instances {
 			'GFCalc(' . $form['id'] . ','                                       => 'GFCalc(' . $random_id . ',',
 			'gf_global["number_formats"][' . $form['id'] . ']'                  => 'gf_global["number_formats"][' . $random_id . ']',
 			'gform_next_button_' . $form['id'] . '_'                            => 'gform_next_button_' . $random_id . '_',
-			$hidden_field                                                       => "<input type='hidden' name='gform_random_id' value='" . $random_id . "' />" . $hidden_field,
+			$hidden_field                                                       => "<input type='hidden' name='gform_instance_count' value='" . $this->instance_counts[ $form['id'] ] . "' /><input type='hidden' name='gform_original_id' value='" . $form['id'] . "' /><input type='hidden' name='gform_random_id' value='" . $random_id . "' />" . $hidden_field,
 		);
 
 		// allow addons & plugins to add additional find & replace strings


### PR DESCRIPTION
This happens when there are more than one form on the page, and at least one of them is set to submit *without* ajax. If this submission results in validation errors, then the original code was setting $_POST['gform_random_id'] for *all* of the forms on the page, not just for the one that was failing. This resulted in, among other things, conditional logic for all but the last form on the page, to break (because window['gf_form_conditional_logic'] was being overwritten by every form). 

This fix tries to detect when a $_POST['gform_random_id'] takes place, and only re-use that id for the form that originally had it. All other forms get new random ids. 

The only use case that I could find that is still problematic is when there are more than one form of the same type on the page, and one is set to submit via ajax, and the other is not. This doesn't work - all forms of the same type need to use the same submission methods (ajax, or non-ajax). Forms of different types, however, can be set to have different submission methods, without a problem. 